### PR TITLE
Correction: rows come before columns when one considers matrices.

### DIFF
--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/10_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/10_13.hpp
@@ -82,8 +82,8 @@ License, or any later version. */
    <li> Generating simplest small scale AES for 10 rounds (with MixColumns):
    \verbatim
 num_rounds : 10$
-num_columns : 1$
 num_rows : 1$
+num_columns : 1$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/1_13.hpp
@@ -51,8 +51,8 @@ License, or any later version. */
    <li> Generating simplest small scale AES for 1 round:
    \verbatim
 num_rounds : 1$
-num_columns : 1$
 num_rows : 1$
+num_columns : 1$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/1_13.hpp
@@ -69,8 +69,8 @@ maxima> ss_mixcolumns_matrix(2,4,2);
    <li> Generating small scale AES for 1 + 1/3 rounds:
    \verbatim
 rounds : 1$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$
@@ -236,8 +236,8 @@ VALID
    <li> Generating small scale AES for 1,...,10 rounds:
    \verbatim
 round : 1$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_rbase_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/20_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/20_13.hpp
@@ -78,8 +78,8 @@ maxima> ss_mixcolumns_matrix(2,4,2);
    <li> Generating small scale AES for twenty rounds:
    \verbatim
 rounds : 20$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$
@@ -305,8 +305,8 @@ c CPU time              : 133.51 s
    <li> Generating small scale AES for twenty rounds (with MixColumns):
    \verbatim
 rounds : 20$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/2_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/2_13.hpp
@@ -61,8 +61,8 @@ shell> cd aes_2_2_4/canon
 shell> oklib --maxima
 oklib_load_all()$
 num_rounds : 2$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$
@@ -188,8 +188,8 @@ shell> cd aes_2_2_4/1base
 shell> oklib --maxima
 oklib_load_all()$
 num_rounds : 2$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_rbase_box$
@@ -315,8 +315,8 @@ shell> cd aes_2_2_4/min
 shell> oklib --maxima
 oklib_load_all()$
 num_rounds : 2$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_small_box$
@@ -444,8 +444,8 @@ shell> cd aes_2_2_4/full
 shell> oklib --maxima
 oklib_load_all()$
 num_rounds : 2$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_full_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/4_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/4_13.hpp
@@ -68,8 +68,8 @@ maxima> ss_mixcolumns_matrix(2,4,2);
    <li> Generating small scale AES for 4 + 1/3 rounds:
    \verbatim
 rounds : 4$
-num_columns : 2$
 num_rows : 2$
+num_columns : 2$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/1_13.hpp
@@ -86,8 +86,8 @@ maxima> ss_mixcolumns_matrix(2,4,2);
    <li> Generating small scale AES for 1 + 1/3 round:
    \verbatim
 num_rounds : 1$
-num_columns : 4$
 num_rows : 2$
+num_columns : 4$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/3_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/3_13.hpp
@@ -74,8 +74,8 @@ maxima> ss_mixcolumns_matrix(2,4,2);
    <li> Generating small scale AES for 1 + 1/3 round:
    \verbatim
 num_rounds : 3$
-num_columns : 4$
 num_rows : 2$
+num_columns : 4$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/5_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/5_13.hpp
@@ -75,8 +75,8 @@ maxima> ss_mixcolumns_matrix(2,4,2);
    <li> Generating small scale AES for 5 + 1/3 round:
    \verbatim
 num_rounds : 5$
-num_columns : 4$
 num_rows : 2$
+num_columns : 4$
 exp : 4$
 final_round_b : false$
 box_tran : aes_rbase_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/1_16_4/4_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/1_16_4/4_13.hpp
@@ -46,8 +46,8 @@ License, or any later version. */
    <li> Generating small scale AES for 4 + 1/3 rounds:
    \verbatim
 num_rounds : 4$
-num_columns : 16$
 num_rows : 1$
+num_columns : 16$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$
@@ -171,8 +171,8 @@ CPU time              : 18.79 s
    <li> Generating small scale AES for 4 + 1/3 rounds:
    \verbatim
 num_rounds : 4$
-num_columns : 16$
 num_rows : 1$
+num_columns : 16$
 exp : 4$
 final_round_b : false$
 box_tran : aes_rbase_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/1_16_4/5_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/1_16_4/5_13.hpp
@@ -46,8 +46,8 @@ License, or any later version. */
    <li> Generating small scale AES for 5 + 1/3 rounds:
    \verbatim
 num_rounds : 5$
-num_columns : 16$
 num_rows : 1$
+num_columns : 16$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$
@@ -156,8 +156,8 @@ CPU time              : 25.4 s
    <li> Generating small scale AES for 5 + 1/3 rounds:
    \verbatim
 num_rounds : 5$
-num_columns : 16$
 num_rows : 1$
+num_columns : 16$
 exp : 4$
 final_round_b : false$
 box_tran : aes_rbase_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/4_4_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/4_4_4/1_13.hpp
@@ -65,8 +65,8 @@ maxima> ss_mixcolumns_matrix(2,4,4);
    <li> Generating small scale AES for one round:
    \verbatim
 num_rounds : 1$
-num_columns : 4$
 num_rows : 4$
+num_columns : 4$
 exp : 4$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/1_16_8/2_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/1_16_8/2_13.hpp
@@ -45,8 +45,8 @@ License, or any later version. */
    <li> Generating AES for 2 + 1/3 round:
    \verbatim
 num_rounds : 2$
-num_columns : 16$
 num_rows : 1$
+num_columns : 16$
 exp : 8$
 final_round_b : false$
 box_tran : aes_ts_box$

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/0_23_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/0_23_13.hpp
@@ -1,3 +1,4 @@
+
 // Matthew Gwynne, 15.2.2011 (Swansea)
 /* Copyright 2011 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
@@ -58,8 +59,8 @@ License, or any later version. */
    <li> Generating AES-instance for 0 + 2/3 + 1/3 round:
    \verbatim
 num_rounds : 1;
-num_columns : 4;
 num_rows : 4;
+num_columns : 4;
 exp : 8;
 final_round_b : true;
 box_tran : aes_ts_box;

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/1_13.hpp
@@ -77,8 +77,8 @@ maxima> ss_mixcolumns_matrix(2,8,4);
    <li> Generating AES for 1 + 1/3 round:
    \verbatim
 num_rounds : 1$
-num_columns : 4$
 num_rows : 4$
+num_columns : 4$
 exp : 8$
 final_round_b : false$
 box_tran : aes_ts_box$


### PR DESCRIPTION
Branch: ticket_14.

Corrected order of rows and columns in code fragments in AES experiment plans.

Matthew
