### PR TITLE
Correction: removing the notion of "linear diffusion" from AES plans.

### DIFF
--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/20_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/20_13.hpp
@@ -20,17 +20,6 @@ License, or any later version. */
   </ul>
 
 
-  \todo Remove linear diffusion from translation
-  <ul>
-   <li> Currently the AES linear diffusion operation creates equality
-   clauses in the translation of this AES instance, as the translation
-   does not check if the MixColumns matrix is the identity matrix. </li>
-   <li> These equivalences clauses can only get in the way for the solvers
-   and skew results, and therefore the translation should be updated to
-   check for the identity matrix and rename variables instead. </li>
-  </ul>
-
-
   \todo Comparison of box translations
   <ul>
    <li> All translations are solved by all solvers in less than 0.5s and so

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/general.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/004/1_1_4/general.hpp
@@ -66,11 +66,13 @@ License, or any later version. */
   </ul>
 
 
-  \todo Remove linear diffusion from translation
+  \todo Remove ShiftRows from translation
   <ul>
-   <li> Currently the AES linear diffusion operation creates equality
+   <li> Currently the AES ShiftRows operation creates equality
    clauses in the translation of this AES instance, as the translation
    does not check if the MixColumns matrix is the identity matrix. </li>
+   <li> That is, the addition constraints are "unary" additions, i.e.,
+   just equality constraints. </li>
    <li> These equivalences clauses can only get in the way for the solvers
    and skew results, and therefore the translation should be updated to
    check for the identity matrix and rename variables instead. </li>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/1_13.hpp
@@ -30,32 +30,8 @@ License, or any later version. */
    <ol>
     <li> Addition of round key 0 (input key) to plaintext. </li>
     <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-    <li> Application of linear diffusion operation. </li>
+    <li> Application of MixColumns operation. </li>
     <li> Addition of round key 1, resulting in the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation.
-   XXX this is irrelevant inforamtion --- such information should go to
-   general.hpp in this directory --- with links to the Maxima-specication!
-   XXX </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of: XXX we don't speak of "linear diffusion"
-   anymore XXX irrelevant to spefify the operations --- but what is missing
-   is *structural information*, stating the main *structural* parameters XXX
-   <ol>
-    <li> A shift of row i by i-1 to the left for all i from 1 to the number of
-    rows. </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,2);
- matrix([x+1,x],[x,x+1])
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
   </ul>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/20_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/20_13.hpp
@@ -31,29 +31,10 @@ License, or any later version. */
     <ol>
      <li> Addition of round key (n-1). </li>
      <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-     <li> Application of linear diffusion operation. </li>
+     <li> Application of MixColumns operation. </li>
     </ol>
     </li>
     <li> Addition of round key 20 yielding the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A shift of row i by i-1 to the left for all i from 1 to the number of
-    rows. </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,2);
- matrix([x+1,x],[x,x+1])
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
   </ul>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/4_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/016/2_2_4/4_13.hpp
@@ -32,29 +32,10 @@ License, or any later version. */
     <ol>
      <li> Addition of round key (n-1). </li>
      <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-     <li> Application of linear diffusion operation. </li>
+     <li> Application of MixColumns operation. </li>
     </ol>
     </li>
     <li> Addition of round key 4 yielding the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A shift of row i by i-1 to the left for all i from 1 to the number of
-    rows. </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,2);
- matrix([x+1,x],[x,x+1])
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
   </ul>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/1_13.hpp
@@ -30,28 +30,8 @@ License, or any later version. */
    <ol>
     <li> Addition of round key 0 (input key) to plaintext. </li>
     <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-    <li> Application of linear diffusion operation. </li>
+    <li> Application of MixColumns operation. </li>
     <li> Addition of round key 1, resulting in the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A cyclical shift of row 2 of the matrix by one 4-bit element to the
-    left, that is, the matrix matrix([1,2],[3,4]) would map to 
-    matrix([1,2],[4,3]). </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,2);
- matrix([x+1,x],[x,x+1]
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
    <li> In this file, we collect:
@@ -65,9 +45,9 @@ maxima> ss_mixcolumns_matrix(2,4,2);
 
   \todo Using the canonical box translation
   <ul>
-   <li> In this translation of the AES cipher, the cipher is 
+   <li> In this translation of the AES cipher, the cipher is
    decomposed into rounds, and then each round is decomposed into
-   SubBytes, and linear diffusion operations, which are then further
+   SubBytes, and MixColumns operations, which are then further
    decomposed into Sbox and multiplication constraints along with
    addition (XOR) constraints. We have:
    <ul>
@@ -79,7 +59,7 @@ maxima> ss_mixcolumns_matrix(2,4,2);
     <li> Addition (XOR) constraints, translated using the prime
     implicates for each constraint. </li>
    </ul>
-   Note that the linear diffusion operation is translated as the
+   Note that the MixColumns operation is translated as the
    conjunction of translation of the operation and it's inverse,
    and so there are 32 multiplication operations, rather than 16.
    </li>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/3_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/3_13.hpp
@@ -33,29 +33,9 @@ License, or any later version. */
     <ol>
      <li> Addition of round key i-1 to plaintext. </li>
      <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-     <li> Application of linear diffusion operation. </li>
+     <li> Application of MixColumns operation. </li>
     </ol>
     <li> Addition of round key 3, resulting in the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A cyclical shift of row 2 of the matrix by one 4-bit element to the
-    left, that is, the matrix matrix([1,2],[3,4]) would map to 
-    matrix([1,2],[4,3]). </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,2);
- matrix([x+1,x],[x,x+1]
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
    <li> In this file, we collect:

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/5_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/2_4_4/5_13.hpp
@@ -33,29 +33,9 @@ License, or any later version. */
     <ol>
      <li> Addition of round key i-1 to plaintext. </li>
      <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-     <li> Application of linear diffusion operation. </li>
+     <li> Application of MixColumns operation. </li>
     </ol>
     <li> Addition of round key 5, resulting in the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A cyclical shift of row 2 of the matrix by one 4-bit element to the
-    left, that is, the matrix matrix([1,2],[3,4]) would map to 
-    matrix([1,2],[4,3]). </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,2);
- matrix([x+1,x],[x,x+1]
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
    <li> In this file, we collect:

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/4_2_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/4_2_4/1_13.hpp
@@ -30,27 +30,8 @@ License, or any later version. */
    <ol>
     <li> Addition of round key 0 (input key) to plaintext. </li>
     <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-    <li> Application of linear diffusion operation. </li>
+    <li> Application of MixColumns operation. </li>
     <li> Addition of round key 1, resulting in the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is a non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A shift of row i by i-1 to the left for all i from 1 to the number of
-    rows. </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,4);
- matrix([x,x+1,1,1],[1,x,x+1,1],[1,1,x,x+1],[x+1,1,1,x])
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
   </ul>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/4_2_4/2_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/032/4_2_4/2_13.hpp
@@ -30,29 +30,11 @@ License, or any later version. */
    <ol>
     <li> Addition of round key 0 (input key) to plaintext. </li>
     <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-    <li> Application of linear diffusion operation. </li>
+    <li> Application of MixColumns operation. </li>
     <li> Addition of round key 1, resulting in the ciphertext. </li>
     <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-    <li> Application of linear diffusion operation. </li>
+    <li> Application of MixColumns operation. </li>
     <li> Addition of round key 2, resulting in the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A shift of row i by i-1 to the left for all i from 1 to the number of rows.. </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix 
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,4,4);
- matrix([x,x+1,1,1],[1,x,x+1,1],[1,1,x,x+1],[x+1,1,1,x])
-    \endverbatim
-    over the 4-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix. </li>
    </ol>
    </li>
   </ul>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/4_4_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/4_4_4/1_13.hpp
@@ -31,27 +31,8 @@ License, or any later version. */
     <ol>
      <li> Addition of round key 0 (input key) to plaintext. </li>
      <li> Application of SubBytes (Sbox to each 4-bit element) operation. </li>
-     <li> Application of linear diffusion operation. </li>
+     <li> Application of MixColumns operation. </li>
      <li> Addition of round key 1, resulting in the ciphertext. </li>
-    </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 4-bit elements,
-   defined as inversion within the 4-bit field composed with an affine
-   transformation. </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-    <ol>
-     <li> A shift of row i by i-1 to the left for all i from 1 to the number of
-     rows. </li>
-     <li> The AES MixColumns operation, which takes the input matrix and
-     applies a matrix multiplication by the constant matrix 
-     \verbatim
-maxima> ss_mixcolumns_matrix(2,4,4);
- matrix([x,x+1,1,1],[1,x,x+1,1],[1,1,x,x+1],[x+1,1,1,x])
-     \endverbatim
-     over the 4-bit field. As it is a matrix multiplication, this operation can
-     be broken down into a "MixColumn" operation on each column of the input
-     matrix. </li>
     </ol>
    </li>
   </ul>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/0_23_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/0_23_13.hpp
@@ -39,8 +39,7 @@ License, or any later version. */
    <ol>
     <li> Addition of round key 0 (input key) to plaintext. </li>
     <li> Application of SubBytes (Sbox to each 8-bit element) operation. </li>
-    <li> A shift of row i by i-1 to the left for all i from 1 to the number of
-    rows. </li>
+    <li> A shift of row i by i-1 to the left for all i in {1,...,4}. </li>
     <li> Addition of round key 1, resulting in the ciphertext. </li>
    </ol>
    </li>

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/128/4_4_8/1_13.hpp
@@ -36,34 +36,8 @@ License, or any later version. */
    <ol>
     <li> Addition of round key 0 (input key) to plaintext. </li>
     <li> Application of SubBytes (Sbox to each 8-bit element) operation. </li>
-    <li> Application of linear diffusion operation. </li>
+    <li> Application of MixColumns operation. </li>
     <li> Addition of round key 1, resulting in the ciphertext. </li>
-   </ol>
-   </li>
-   <li> The Sbox is non-linear permutation over the set of 8-bit elements,
-   defined as inversion within the 8-bit field composed with an affine
-   transformation.
-   ??? One shouldn't have such general information at such low-level files:
-   the parameters are important, and reminders about their meaning, but NOT
-   such general information ???
-   </li>
-   <li> The linear diffusion operation applies a linear permutation to
-   the input matrix, consisting of:
-   <ol>
-    <li> A shift of row i by i-1 to the left for all i from 1 to the number of
-    rows. </li>
-    <li> The AES MixColumns operation, which takes the input matrix and
-    applies a matrix multiplication by the constant matrix
-    \verbatim
-maxima> ss_mixcolumns_matrix(2,8,4);
- matrix([x,x+1,1,1],[1,x,x+1,1],[1,1,x,x+1],[x+1,1,1,x])
-    \endverbatim
-    over the 8-bit field. As it is a matrix multiplication, this operation can
-    be broken down into a "MixColumn" operation on each column of the input
-    matrix.
-    ??? Again, this general information is misplaced --- one wants to see
-    clearly the general parameters (also information regarding complexity) ???
-    </li>
    </ol>
    </li>
   </ul>


### PR DESCRIPTION
Branch: ticket_15.

Removed notion of linear diffusion, also removing mention of "shifts by rows" etc in AES experiments plans.

Matthew
