### PR TITLE
Solvers report wrong times on some machines.

### DIFF
--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/4_4_4/1_13.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/SAT2011/KeyDiscovery/064/4_4_4/1_13.hpp
@@ -165,23 +165,6 @@ CPU time              : 20.7818 s
    \endverbatim
    This has been verified by hand.
    </li>
-   <li> glucose (apparently) solves this in a fraction of a second:
-   \verbatim
-shell> glucose experiment_r1_k1.cnf
-c restarts              : 566
-c conflicts             : 12127207       (92588235 /sec)
-c decisions             : 12923545       (1.40 % random) (98668079 /sec)
-c propagations          : 5248749924     (40072911315 /sec)
-c CPU time              : 0.13098 s
-   \endverbatim
-   however, re-running glucose does not yield the same behaviour, and there
-   are a very large number of restarts in just 0.13s. Does glucose have a bug
-   in it's timing code? Perhaps there is a bug in the experiment run script?
-   See "MiniSAT2 based solvers return incorrect times using experiment script"
-   in
-   Investigations/Cryptography/AdvancedEncryptionStandard/plans/general.hpp.
-??? This is trivial to fix --- just apply "time" ???
-   </li>
    <li> Other solvers such as cryptominisat take longer (but still only a few
    minutes):
    \verbatim
@@ -201,6 +184,34 @@ c 95 simplifications, 10 reductions
 c prps: 3155560431 propagations, 0.70 megaprops
 c 4505.6 seconds, 56 MB max, 1732 MB recycled
    \endverbatim
+   </li>
+   <li> glucose takes over 3 hours:
+   \verbatim
+shell> time glucose experiment_r1_k1.cnf
+c restarts              : 566
+c conflicts             : 12127207       (1021 /sec)
+c decisions             : 12923545       (1.40 % random) (1088 /sec)
+c propagations          : 5248749924     (441984 /sec)
+c CPU time              : 11875.4 s
+
+real	198m9.532s
+user	197m55.440s
+sys	0m1.020s
+   \endverbatim
+   </li>
+   <li> DONE (reran experiment; see above)
+   glucose (apparently) solves this in a fraction of a second:
+   \verbatim
+shell> glucose experiment_r1_k1.cnf
+c restarts              : 566
+c conflicts             : 12127207       (92588235 /sec)
+c decisions             : 12923545       (1.40 % random) (98668079 /sec)
+c propagations          : 5248749924     (40072911315 /sec)
+c CPU time              : 0.13098 s
+   \endverbatim
+   however, re-running glucose does not yield the same behaviour, and there
+   are a very large number of restarts in just 0.13s. Does glucose have a bug
+   in it's timing code? Perhaps there is a bug in the experiment run script?
    </li>
 ??? where are 2 rounds etc.? where is the general plans-file ???
   </ul>


### PR DESCRIPTION
Solvers return incorrect times on some machines.

This appears to be a linux kernel bug on 32-bit machines with old (but still fairly recent) kernels.

I have added this as a todo, as I feel including it in the history is useful for others using the OKlibrary who might have a similar issue (and the todo will likely disappear quickly).

Note that for CP2011, I ran all instances with the time command and used the time from that, as can be seen in ticket_61, so the data there is still correct.

Now updated to include solver names, and running PHP instances which are much simpler instances and easy to generate.

Matthew
