### PR TITLE
BUG: ExtractMinisat returns number of clauses after preprocessing as "c".

### DIFF
--- a/Experimentation/ExperimentSystem/SolverMonitoring/ExtractMinisat.awk
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/ExtractMinisat.awk
@@ -10,9 +10,9 @@
 
 # The fields must be exactly as given by headers/minisat.
 
-BEGIN { n=0;c=0;t=0;sat=2;cfs=0;dec=0;rts=0;r1=0;mem=0;ptime=0;stime=0;cfl=0; }
+BEGIN { n=0;apc=0;t=0;sat=2;cfs=0;dec=0;rts=0;r1=0;mem=0;ptime=0;stime=0;cfl=0; }
 /^\|  *Number of variables:/ { n=$5; }
-/^\|  *Number of clauses:/ { c=$5; }
+/^\|  *Number of clauses:/ { apc=$5; }
 /^CPU time +: ([0-9]+|[0-9]+.[0-9]+) s/ { t=$4; }
 /^UNSATISFIABLE *$/ { sat=0; }
 /^SATISFIABLE *$/ { sat=1; }
@@ -25,5 +25,5 @@ BEGIN { n=0;c=0;t=0;sat=2;cfs=0;dec=0;rts=0;r1=0;mem=0;ptime=0;stime=0;cfl=0; }
 /^\|  *Pars(e|ing) time:/ { ptime=$4; }
 /^\|  *Simplification time:/ { stime=$4; }
 /^conflict literals +:/ { cfl=$4; }
-END { print n " " c " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " \
+END { print n " " apc " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " \
         ptime " " stime " " cfl; }

--- a/Experimentation/ExperimentSystem/SolverMonitoring/headers/minisat
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/headers/minisat
@@ -1,1 +1,1 @@
-n c t sat cfs dec rts r1 mem ptime stime cfl
+n apc t sat cfs dec rts r1 mem ptime stime cfl

--- a/Experimentation/ExperimentSystem/SolverMonitoring/plans/general.hpp
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/plans/general.hpp
@@ -10,6 +10,29 @@ License, or any later version. */
   \brief General plans regarding monitoring solvers
 
 
+  \todo minisat-2.2.0 doesn't output initial number of clauses
+  <ul>
+   <li> minisat-2.2.0 prints out the number of clauses *after*
+   preprocessing, but doesn't list the initial number of clauses. </li>
+   <li> All other solvers (OKsolver_2002, precosat236, precosat-570.1,
+   satz215, sat-grasp, cryptominisat, glucose, march_pl) do provide
+   the initial number of clauses. </li>
+   <li> The initial number of variables and clauses are important pieces
+   of data about the CNF being investigated. </li>
+   <li> We should provide a way to ensure that this data is included
+   when minisat-2.2.0 is run. We could:
+    <ul>
+     <li> update RunMinisat to output the number of initial clauses
+     to its Statistics file; </li>
+     <li> add a wrapper script for minisat-2.2.0 which outputs the
+     initial number of clauses; </li>
+     <li> contact the minisat-2.2.0 authors and ask that the initial
+     number of clauses be included somehow in the output. </li>
+    </ul>
+   </li>
+  </ul>
+
+
   \todo Running experiments
   <ul>
    <li> Currently we have RunMinisat. </li>
@@ -149,6 +172,7 @@ License, or any later version. */
     <ol>
      <li> n : integer, number of variables. </li>
      <li> c : integer, number of clauses. </li>
+     <li> apc : integer, number of clauses after preprocessing. </li>
      <li> l : integer, number of literal occurrences. </li>
      <li> Such general measures always refer to the original input (not
      after preprocessing). </li>

--- a/Experimentation/ExperimentSystem/SolverMonitoring/plans/milestones.hpp
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/plans/milestones.hpp
@@ -16,6 +16,7 @@ License, or any later version. */
   \par
    In ExperimentSystem/SolverMonitoring/plans/general.hpp the following topics
    are handled:
+    - minisat-2.2.0 doesn't output initial number of clauses
     - Running experiments
     - Better summary statistics
     - Extraction tools

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/Argo.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/Argo.hpp
@@ -44,7 +44,7 @@ Mem:          3947       1113       2833          0        183        839
 Swap:         2053          0       2053
 
 > echo -n "ub "; ExtractMinisat header-only; for F in Instances/*; do echo -n "$(basename ${F}) "; tail -n1 ExperimentMinisat_Instances$(basename ${F})_*/Statistics; done
-ub n c t sat cfs dec rts r1 mem ptime stime cfl
+ub n apc t sat cfs dec rts r1 mem ptime stime cfl
 13 30867 92535 4.27935 1 4163 4782 22 32241454 20.00 0.05 0.17 53421
 14 31229 93655 13.6159 1 13103 14368 59 105018641 20.00 0.05 0.18 162452
 15 31238 93678 5.72913 1 5452 6451 29 43914380 20.00 0.05 0.18 78501


### PR DESCRIPTION
Branch: extract_minisat.

Add bug on ExtractMinisat returning number of clauses after preprocessing as "c".

Matthew
