### PR TITLE
Editorial corrections.

### DIFF
--- a/Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/3-k/16.hpp
+++ b/Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/3-k/16.hpp
@@ -6,7 +6,7 @@ the Free Software Foundation and included in this library; either version 3 of t
 License, or any later version. */
 
 /*!
-  \file Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/3-k/15.hpp
+  \file Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/3-k/16.hpp
   \brief On investigations into vdw_2(3,16) = 238
 
 

--- a/Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/5-k/06.hpp
+++ b/Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/5-k/06.hpp
@@ -6,7 +6,7 @@ the Free Software Foundation and included in this library; either version 3 of t
 License, or any later version. */
 
 /*!
-  \file Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/5-k/07.hpp
+  \file Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/5-k/06.hpp
   \brief On investigations into vdw_2(5,6) = 206
 
 

--- a/Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/5-k/08.hpp
+++ b/Experimentation/Investigations/RamseyTheory/VanderWaerdenProblems/plans/5-k/08.hpp
@@ -18,6 +18,7 @@ License, or any later version. */
 
 
   \todo vdw_2(5,8) > 330
+  <ul>
    <li> Certificate for n=330:
    \verbatim
 3,4,5,6,9,12,13,14,21,22,


### PR DESCRIPTION
Editorial corrections in VDW experimental plans.

Corrected:
- incorrect doxygen filenames;
- missing <ul>.

Matthew
