### PR TITLE
Correction: solvers output solver-specific data on variables, clauses and

### DIFF
--- a/Experimentation/ExperimentSystem/SolverMonitoring/ExtractGlucose.awk
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/ExtractGlucose.awk
@@ -9,10 +9,10 @@
 # Extracts the numerical data from output of the glucose solver, in a single line.
 
 BEGIN { 
-  n=0; c=0; t=0; sat=2; cfs=0; dec=0; rts=0; r1=0; mem=0; ptime=0; cfl=0;
+  rn=0; rc=0; t=0; sat=2; cfs=0; dec=0; rts=0; r1=0; mem=0; ptime=0; cfl=0;
   rdb=0; ldlc=0; l2c=0;l1c=0; }
-/^c +\|  *Number of variables:/ { n=$6; }
-/^c +\|  *Number of clauses:/ { c=$6; }
+/^c +\|  *Number of variables:/ { rn=$6; }
+/^c +\|  *Number of clauses:/ { rc=$6; }
 /^c +CPU time +: ([0-9]+|[0-9]+.[0-9]+) s/ { t=$5; }
 /^s +UNSATISFIABLE *$/ { sat=0; }
 /^s +SATISFIABLE *$/ { sat=1; }
@@ -29,5 +29,5 @@ BEGIN {
 /^c +nb learnts size 1 +:/ { l1c=$7 }
 /^c +\|  *Pars(e|ing) time:/ { ptime=$5; }
 END {
-  print n " " c " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " ptime " "
+  print rn " " rc " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " ptime " "
     cfl " " rdb " " ldlc " " l2c " " l1c; }

--- a/Experimentation/ExperimentSystem/SolverMonitoring/ExtractMarchpl.awk
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/ExtractMarchpl.awk
@@ -8,12 +8,12 @@
 
 # Extracts the numerical data from output of march_pl, in a single line.
 
-BEGIN { n=0;c=0;t=0;sat=2;nds=0;r1=0;r2=0; }
-/^c +initFormula\(\):: the DIMACS p-line indicates a/ { n=$10; c=$13; }
+BEGIN { rn=0;rc=0;t=0;sat=2;nds=0;r1=0;r2=0; }
+/^c +initFormula\(\):: the DIMACS p-line indicates a/ { rn=$10; rc=$13; }
 /^c +main\(\):: time=[0-9\.]+/ { t=substr($3,6); }
 /^s +UNSATISFIABLE *$/ { sat=0; }
 /^s +SATISFIABLE *$/ { sat=1; }
 /^c +main\(\):: nodeCount: [0-9]+/ { nds=$4; }
 /^c +main\(\):: lookAheadCount: [0-9]+/ { r2=$4; }
 /^c +main\(\):: unitResolveCount: [0-9]+/ { r1=$4; }
-END { print n " " c " " t " " sat " " nds " " r1 " " r2 }
+END { print rn " " rc " " t " " sat " " nds " " r1 " " r2 }

--- a/Experimentation/ExperimentSystem/SolverMonitoring/ExtractMinisat.awk
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/ExtractMinisat.awk
@@ -10,9 +10,9 @@
 
 # The fields must be exactly as given by headers/minisat.
 
-BEGIN { n=0;c=0;t=0;sat=2;cfs=0;dec=0;rts=0;r1=0;mem=0;ptime=0;stime=0;cfl=0; }
-/^\|  *Number of variables:/ { n=$5; }
-/^\|  *Number of clauses:/ { c=$5; }
+BEGIN { rn=0;rc=0;t=0;sat=2;cfs=0;dec=0;rts=0;r1=0;mem=0;ptime=0;stime=0;cfl=0; }
+/^\|  *Number of variables:/ { rn=$5; }
+/^\|  *Number of clauses:/ { rc=$5; }
 /^CPU time +: ([0-9]+|[0-9]+.[0-9]+) s/ { t=$4; }
 /^UNSATISFIABLE *$/ { sat=0; }
 /^SATISFIABLE *$/ { sat=1; }
@@ -25,5 +25,5 @@ BEGIN { n=0;c=0;t=0;sat=2;cfs=0;dec=0;rts=0;r1=0;mem=0;ptime=0;stime=0;cfl=0; }
 /^\|  *Pars(e|ing) time:/ { ptime=$4; }
 /^\|  *Simplification time:/ { stime=$4; }
 /^conflict literals +:/ { cfl=$4; }
-END { print n " " c " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " \
+END { print rn " " rc " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " \
         ptime " " stime " " cfl; }

--- a/Experimentation/ExperimentSystem/SolverMonitoring/ExtractPrecosat236.awk
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/ExtractPrecosat236.awk
@@ -9,13 +9,13 @@
 # Extracts the numerical data from output of precosat236, in a single line.
 
 BEGIN {
-  n=0; c=0; t=0; sat=2; cfs=0; dec=0; rts=0; r1=0; mem=0; rnd=0; skip=0; enl=0;
+  rn=0; rc=0; t=0; sat=2; cfs=0; dec=0; rts=0; r1=0; mem=0; rnd=0; skip=0; enl=0;
   shk=0; resc=0; rebi=0; simp=0;red=0; nfix=0; neq=0; nel=0; nmg=0; elres=0;
   elph=0; elr=0; sb=0; sbn=0.0; sba=0.0; sbx=0.0; sbi=0.0; ar=0; arx=0; pb=0;
   pbph=0; pbr=0; pbf=0; pblf=0; pbmg=0; sccnt=0; sccf=0; sccm=0; hshu=0; hshm=0;
   minln=0; mindel=0; minst=0; mind=0; subf=0; subb=0; subdm=0; strf=0; strb=0;
   dom=0; domh=0; domlow=0; mpr=0; memr=0; }
-/^c +found header 'p cnf/ { n=$6; c=$7; sub(/'/,"",c); }
+/^c +found header 'p cnf/ { rn=$6; rc=$7; sub(/'/,"",rc); }
 /^c [0-9]+.[0-9]+ seconds, [0-9]+ MB max, [0-9]+ MB/ { t=$2; mem=$4; memr=$7; }
 /^s +UNSATISFIABLE *$/ { sat=0; }
 /^s +SATISFIABLE *$/ { sat=1; }
@@ -41,7 +41,7 @@ BEGIN {
 /^c +doms: [0-9]+ dominators, [0-9]+ high,/ { dom=$3; domh=$5; domlow=$7; }
 /^c +prps: [0-9]+ propagations, [0-9]+.[0-9]+ megaprops/ { r1=$3; mpr=$5; }
 END {
-  print n " " c " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " \
+  print rn " " rc " " t " " sat " " cfs " " dec " " rts " " r1 " " mem " " \
     rnd " " its " " skip " " enl " " shk " " resc " " rebi " " simp " " \
     red " " nfix " " neq " " nel " " nmg " " sb " " sbn " " sba " " sbx " " \
     sbi " " ar " " arx " " pb " " pbph " " pbr " " pbf " " pblf " " pbmg " " \

--- a/Experimentation/ExperimentSystem/SolverMonitoring/ExtractPrecosat570.awk
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/ExtractPrecosat570.awk
@@ -8,7 +8,7 @@
 # Converts the output of "precosat-570.1 -v to a single line.
 
 BEGIN {
-  n=0; c=0; t=0; sat=0; cfs=0; dec=0; rts=0; r1=0; pls=0; ats=0; mem=0; ptime=0;
+  rn=0; rc=0; t=0; sat=0; cfs=0; dec=0; rts=0; r1=0; pls=0; ats=0; mem=0; ptime=0;
   file=""; rnd=0; its=0; skip=0; enl=0; shk=0; resc=0; rebi=0; simp=0; red=0;
   ar=0; arx=0; atssz=0; bck=0; bckct=0; bckj=0; bckjln=0; blkres=0; blkph=0;
   blkr=0; blk=0; blkimp=0; blkexp=0; clsrec=0; clspur=0; clsaut=0; dom=0;
@@ -20,7 +20,7 @@ BEGIN {
   strorg=0; strasy=0; subf=0; subb=0; subdyn=0; suborg=0; subdm=0; subgc=0;
   srtime=0; otime=0; nfix=0; neq=0; nel=0; npur=0; nzmb=0; naut=0; zmb=0;
   zmbexp=0; zmbel=0; zmbblk=0; memr=0; }
-/^c +found header 'p cnf/ { n=$6; c=$7; sub(/'/,"",c); }
+/^c +found header 'p cnf/ { rn=$6; rc=$7; sub(/'/,"",rc); }
 /^c +[0-9]+.[0-9]+ seconds, [0-9]+ MB max,/ { t=$2; mem=$4; memr=$7; }
 /^s +UNSATISFIABLE *$/ { sat=0; }
 /^s +SATISFIABLE *$/ { sat=1; }
@@ -60,7 +60,7 @@ BEGIN {
   nfix=$3; neq=$5; nel=$7; npur=$9; nzmb=$11; naut=$13; }
 /^c zmbs: 0 = 0 explicit + 0 elim + 0 blkd + 0 autark/ { zmb=$3; zmbexp=$5; zmbel=$8; zmbblk=$11; }
 END {
-  print n " " c " " t " " sat " " cfs " " dec " " rts " " r1 " " pls " " \
+  print rn " " rc " " t " " sat " " cfs " " dec " " rts " " r1 " " pls " " \
     ats " " mem " " ptime " \"" file "\" " rnd " " its " " skip " " enl " " \
     shk " " resc " " rebi " " simp " " red " "  ar " " arx " " atssz " " \
     bck " " bckct " " bckj " " bckjln " " blkres " " blkph " " blkr " " \

--- a/Experimentation/ExperimentSystem/SolverMonitoring/ExtractSatz.awk
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/ExtractSatz.awk
@@ -9,14 +9,14 @@
 # Extracts the numerical data from output of satz215, in a single line.
 
 BEGIN {
-  n=0; c=0; t=0; sat=2; nds=0; r1=0; file=""; bck=0; src=0; fix=0; dc=0;
+  rn=0; rc=0; t=0; sat=2; nds=0; r1=0; file=""; bck=0; src=0; fix=0; dc=0;
   src2=0;fix2=0; }
 /^satz215 ([^ ]+ )+/ { 
-  file=$2; nds=$4; bck=$5; src=$6; fix=$7; sat=$8; n=$9; c=$10; dc=-$11;
+  file=$2; nds=$4; bck=$5; src=$6; fix=$7; sat=$8; rn=$9; rc=$10; dc=-$11;
   src2=$12; fix2=$13; }
 /^NB_MONO= / { pls=$2; sub(/,/, "",pls); r1=$4; sub(/,/, "",r1); }
 /^real	[0-9]+m[0-9\.]+s/ { 
   split($2,tarr,"m"); sub(/s/,"", tarr[2]); t=tarr[1]*60 + tarr[2]; }
 END { 
-  print n " " c " " t " " sat " " nds " " r1 " " pls " " file " " bck " " \
+  print rn " " rc " " t " " sat " " nds " " r1 " " pls " " file " " bck " " \
     src " " fix " " dc " " src2 " " fix2; }

--- a/Experimentation/ExperimentSystem/SolverMonitoring/headers/minisat
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/headers/minisat
@@ -1,1 +1,1 @@
-n c t sat cfs dec rts r1 mem ptime stime cfl
+rn rc t sat cfs dec rts r1 mem ptime stime cfl

--- a/Experimentation/ExperimentSystem/SolverMonitoring/plans/general.hpp
+++ b/Experimentation/ExperimentSystem/SolverMonitoring/plans/general.hpp
@@ -48,6 +48,12 @@ License, or any later version. */
      from filenames; see also "Extraction tools". </li>
     </ul>
    </li>
+   <li> These scripts should also (at least) collect full data on the true
+   number of variables, clauses and literals present in the instance, adding
+   this data to the Statistics file as the n, c and l columns. </li>
+   <li> We likely also want to collect more statistics on
+   these instances, for example, min/max/avg clause-length, deficiency and so
+   on. </li>
    <li> We need scripts like that for all solvers. </li>
   </ul>
 
@@ -148,10 +154,14 @@ License, or any later version. */
    <li> Standardised column names:
     <ol>
      <li> n : integer, number of variables. </li>
+     <li> rn : integer, number of variables as reported by the solver. </li>
      <li> c : integer, number of clauses. </li>
+     <li> rc : integer, number of clauses, as reported by the solver. </li>
      <li> l : integer, number of literal occurrences. </li>
-     <li> Such general measures always refer to the original input (not
-     after preprocessing). </li>
+     <li> rl : integer, number of literal occurrences, as reported by the
+     solver. </li>
+     <li> Such general measures (n, c and l) always refer to the original
+     input (not after preprocessing). </li>
      <li> t : double, solution time (in seconds). </li>
      <li> sat : in {0,1,2} for UNSAT, SAT, UNKNOWN. </li>
      <li> nds : double, number of nodes for look-ahead solvers. </li>

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/Argo.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/Argo.hpp
@@ -44,7 +44,7 @@ Mem:          3947       1113       2833          0        183        839
 Swap:         2053          0       2053
 
 > echo -n "ub "; ExtractMinisat header-only; for F in Instances/*; do echo -n "$(basename ${F}) "; tail -n1 ExperimentMinisat_Instances$(basename ${F})_*/Statistics; done
-ub n c t sat cfs dec rts r1 mem ptime stime cfl
+ub rn rc t sat cfs dec rts r1 mem ptime stime cfl
 13 30867 92535 4.27935 1 4163 4782 22 32241454 20.00 0.05 0.17 53421
 14 31229 93655 13.6159 1 13103 14368 59 105018641 20.00 0.05 0.18 162452
 15 31238 93678 5.72913 1 5452 6451 29 43914380 20.00 0.05 0.18 78501


### PR DESCRIPTION
Branch: extract_minisat.

Renaming extracted columns "n", "c" and "l" to "rn", "rc" and "rl" for solver-specific data and added todo todo on RunMinisat etc, suggesting computation of true statistics by experiment scripts.

Matthew
