### PR TITLE
Ticket 78

### DIFF
--- a/Buildsystem/ExternalSources/SpecialBuilds/plans/Gcc.hpp
+++ b/Buildsystem/ExternalSources/SpecialBuilds/plans/Gcc.hpp
@@ -287,22 +287,31 @@ ExternalSources> oklib gcc gcc_user_options_okl="--with-system-zlib"
 
   \todo Latest texi2dvi fails to build gcc.texi on some systems
   <ul>
-   <li> Request to specify which version of texi2dvi this was about; and also,
-   for such issues dates need to be stated. </li>
-   <li> The latest texinfo package has a bug due to the formatting of
-   strings passed to egrep, which results in an error from texi2dvi during
-   the gcc (4.5.2) build process complaining about precisely this. </li>
-   <li> The error arises as texi2dvi uses egrep with using "[A-z]" rather
-   than "[A-Za-z]", and the first isn't a valid pattern when using certain
-   unicode (UTF-8 type) character sets. </li>
-   <li> DONE (we should avoid such hacks if possible, and here it is)
-   One can run "LC_ALL=C oklib gcc" and the build completes without a
-   problem. </li>
-   <li> According to
+   <li> Texinfo packages from at least as far back as version 1.1 (from 2002)
+   have a bug due to the formatting of strings passed to egrep. </li>
+   <li> This bug results in an error from texi2dvi during the gcc
+   build process. </li>
+   <li> This has now been fixed by providing an corrected version of texi2dvi
+   within the OKlibrary. </li>
+   <li> Whether one sees errors from this bug is locale dependent. </li>
+   <li> MG first noticed this problem in Dec 2010. </li>
+   <li> The bug was fixed in the CVS version of the texinfo package in March
+   2010, visible at
+   http://cvs.savannah.gnu.org/viewvc/texinfo/texinfo/util/texi2dvi?r1=1.157&r2=1.158 .
+   </li>
+   <li> However, the last official texinfo release was in 2008. </li>
+   <li> We should send an e-mail to the texinfo mailing list asking why there
+   has been no new official release. </li>
+   <li> DONE (correction applied in gcc-building) According to
    http://www.mail-archive.com/bug-texinfo@gnu.org/msg04519.html
    and the corresponding bug report, there is now a fix, and presumably
    this should be available in a new texinfo package soon on most systems.
    </li>
+   <li> DONE (we should avoid such hacks if possible, and here it is)
+   One can run "LC_ALL=C oklib gcc" and the build completes without a
+   problem. </li>
+   <li> DONE Request to specify which version of texi2dvi this was about; and
+   also, for such issues dates need to be stated. </li>
    <li> DONE (gcc-building provides now a corrected version)
    This is not a bug in the OKlibrary, but users should be aware of the
    issue. </li>


### PR DESCRIPTION
Branch: ticket_78.

Added details on versions and dates relating to the texi2dvi bug.

The latest release of texinfo was >2.5 years ago, we should provide a newer version from CVS.

Matthew
