### PR TITLE
Editorial correction: removing superfluous newlines from Maxima code.

### DIFF
--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/3.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/3.hpp
@@ -104,7 +104,7 @@ maxima> oklib_load_all()$
    \verbatim
 ExternalSources/builds/SAT/Des/des2fml-0.9> mkdir experiments && cd experiments
 experiments> rounds=3; s=1;
-  cat des_r${rounds}_pkc_triples | while read p k c; do
+  cat des_r${rounds}_pkc_triples | grep -v '^ *$' | while read p k c; do
     echo ${p} | sed -e 's/_/ /g' > plaintxt; echo ${k} | sed -e 's/_/ /g' > key_des; rm ciph_txt
     ./des -r${rounds} && ./des2fml -r${rounds} -p -c -f1 && ./clausify formulae des_massacci_r${rounds}_s${s}.cnf
     let s=$s+1

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/4.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/4.hpp
@@ -100,7 +100,7 @@ maxima> oklib_load_all()$
    \verbatim
 ExternalSources/builds/SAT/Des/des2fml-0.9> mkdir experiments && cd experiments
 experiments> rounds=4; s=1;
-cat des_r${rounds}_pkc_triples | while read p k c; do
+cat des_r${rounds}_pkc_triples | grep -v '^ *$' | while read p k c; do
   echo ${p} | sed -e 's/_/ /g' > plaintxt; echo ${k} | sed -e 's/_/ /g' > key_des; rm ciph_txt
   ./des -r${rounds} && ./des2fml -r${rounds} -p -c -f1 && ./clausify formulae des_massacci_r${rounds}_s${s}.cnf
   let s=$s+1

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/5.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/KeyDiscovery/5.hpp
@@ -104,7 +104,7 @@ maxima> oklib_load_all()$
    \verbatim
 ExternalSources/builds/SAT/Des/des2fml-0.9> mkdir experiments && cd experiments
 experiments> rounds=5; s=1;
-cat des_r${rounds}_pkc_triples | while read p k c; do
+cat des_r${rounds}_pkc_triples | grep -v '^ *$' | while read p k c; do
   echo ${p} | sed -e 's/_/ /g' > plaintxt; echo ${k} | sed -e 's/_/ /g' > key_des; rm ciph_txt
   ./des -r${rounds} && ./des2fml -r${rounds} -p -c -f1 && ./clausify formulae des_massacci_r${rounds}_s${s}.cnf
   let s=$s+1


### PR DESCRIPTION
Branch: misc.

Editorial corrections in plans.

When generating Massacci DES key discovery instances, we generate a file with a list of plaintext-ciphertext pairs to use. This had a new-line between each plaintext-ciphertext pair, which was being read as an "empty" plaintext-ciphertext pair. These new-lines have now been grepped out.

Matthew
