### PR TITLE
Fixing bug in des_comb_sbox_bf.

### DIFF
--- a/ComputerAlgebra/Cryptology/Lisp/CryptoSystems/DataEncryptionStandard/tests/Sboxes.mac
+++ b/ComputerAlgebra/Cryptology/Lisp/CryptoSystems/DataEncryptionStandard/tests/Sboxes.mac
@@ -141,9 +141,9 @@ okltest_des_comb_sbox_bf(f) := block(
   assert(
     f([1,2])([0,1,0,0,1,0,0]) = [1,0]),
   if oklib_test_level = 0 then return(true),
-  assert(
-    create_list(f([1,2,3,4,9,10,11,12])(I),I,lex_bv_l(8)) =
-    create_list(append(des_sbox_bf(1)(I),des_sbox_bf(3)(I)),I,lex_bv_l(8))),
+  assert(block([lex_bv_l_12 : lex_bv_l(12)],
+    create_list(f([1,2,3,4,9,10,11,12])(I),I,lex_bv_l_12) =
+    create_list(append(des_sbox_bf(1)(I),des_sbox_bf(3)(I)),I,lex_bv_l_12))),
   true)$
 
 /*!


### PR DESCRIPTION
Branch: bugfix_des_comb_sbox_bf.

This was due to passing the wrong size vectors to des_comb_sbox_bf in the
test, along with a failure to run tests at the higher test level on the
part of MG.

Matthew
