### PR TITLE
Splitting mhash

### DIFF
--- a/Buildsystem/ExternalSources/SpecialBuilds/plans/Mhash.hpp
+++ b/Buildsystem/ExternalSources/SpecialBuilds/plans/Mhash.hpp
@@ -47,6 +47,13 @@ b7860fed495cd6145a67870630b4975a  mhash-0.9.9.9-force64bit-tiger.patch
      </li>
      <li> Likely we just want the patch files, and so there is no need
      to install the rpm2cpio tool. </li>
+     <li> The same patch files are available from a Fedora git respository
+     at http://pkgs.fedoraproject.org/gitweb/?p=mhash.git :
+     \verbatim
+ExternalSources/sources/Mhash> git clone git://pkgs.fedoraproject.org/mhash.git
+ExternalSources/sources/Mhash> for x in *.patch; do diff $x mhash/$x; done
+     \endverbatim
+     </li>
      <li> Now building Mhash, where
      Buildsystem/ExternalSources/SpecialBuilds/mhash.mak has been changed so
      that


### PR DESCRIPTION
Branch: splitting_mhash.

Mhash builds (and runs) correctly if the RedHat patches are applied.

The patches can be extracted from the rpm, and are available in a git repository (the same exact patches).

Matthew
