### PR TITLE
Pla

### DIFF
--- a/Buildsystem/ExternalSources/SpecialBuilds/plans/BooleanFunctions.hpp
+++ b/Buildsystem/ExternalSources/SpecialBuilds/plans/BooleanFunctions.hpp
@@ -146,8 +146,9 @@ ExternalSources/Installations/R> oklib --R
      information in
      ExternalSources/sources/Boolean/Espresso/man_octtools_espresso.html. </li>
      <li> A PLA file represents m partial boolean functions,
-     f_i : {0,1}^n -> {0,1} for i in {1,...,m}, by encoding a table of
-     rows of n+m values in {0,1,-}. </li>
+     f_i : A_i -> {0,1} for i in {1,...,m} and A_i a subset of {0,1}^n. </li>
+     <li> It does this by encoding a table of rows of n+m values in {0,1,-}.
+     </li>
      <li> The PLA file starts with a header and other commands followed
      by a (possibly empty) list of data-lines. </li>
      <li> Lines starting with # are comments, and can appear at any place in
@@ -191,6 +192,27 @@ ExternalSources/Installations/R> oklib --R
      <li> For all i in {1,...,m}, f_i is considered to be 0
      for inputs which were not specified in the PLA, although this
      interpretation can be changed using the ".type" option.
+     </li>
+     <li> Data-lines should not specify conflicting values for any
+     of the partial boolean functions. </li>
+     <li> So, by default, for all i in {1,...,m}, we have that
+     f_i : A_i -> {0,1} is defined such that
+      <ul>
+       <li> A_i is the subset of {0,1}^n; </li>
+       <li> Vector V is in A_i if there is *no* data-line in the PLA file
+       such that V = I modulo substition of "-" characters, and O[i] = "-";
+       </li>
+       <li> f_i(V) = 1 if there exists a data-line in the PLA file where
+       V = I modulo substitution of "-" characters and O[i] = 1; </li>
+       <li> f_i(V) = 0 if either
+        <ul>
+         <li> there exists a data-line in the PLA file where
+         V = I modulo substitution of "-" characters and O[i] = 0, or </li>
+         <li> there doesn't exist a data-line in the PLA file such that
+         V = I modulo substitution of "-" characters at all. </li>
+        </ul>
+       </li>
+      </ul>
      </li>
      <li> The type option,
      \verbatim

--- a/ComputerAlgebra/Satisfiability/Lisp/ClauseSets/BasicOperations.mac
+++ b/ComputerAlgebra/Satisfiability/Lisp/ClauseSets/BasicOperations.mac
@@ -406,8 +406,8 @@ read_fcl_f(n) := block([fh, line, ll,p_n, p_found : false],
 /* This has no place here, but should be under boolean functions. */
 
 /* A file in the PLA format represents m partial nx1 boolean functions,
-   f_i : {0,1}^n -> {0,1} for i in {1,...,m} by encoding a table of
-   {0,1,-} values.
+   f_i : A_i -> {0,1} for i in {1,...,m} and A_i a subset of {0,1}^n.
+   This is done by encoding a table of {0,1,-} values.
 
    A PLA file starts with a header of the form:
 
@@ -432,7 +432,9 @@ read_fcl_f(n) := block([fh, line, ll,p_n, p_found : false],
           f_i(I') is undefined    otherwise.
 
    By default, for all i in {1,...,m}, f_i is considered to be 0 for inputs
-   which are not specified in the PLA.
+   which are not specified in the PLA. Data-lines should not conflict with
+   each other, in the sense that f_i(I') should not be defined to be both
+   1 and 0, or 1 and "-" etc.
 
    For more information on the PLA format, see
    "Improve documentation for Espresso" in


### PR DESCRIPTION
Branch: pla.

Correcting the specification of the PLA format. It specifies multiple partial boolean functions, not a finite function. This is due to the fact that individual output bits can be specified as "dont-care", i.e., undefined, while others can be specified.

Now also correcting the notation used for partial boolean functions and adding an explicit specification of what these partial boolean functions are.

Matthew
