### PR TITLE
Updating and correcting copyright dates for recently updated files.

### DIFF
--- a/ComputerAlgebra/Cryptology/Lisp/CryptoSystems/KeeLoq/include.mac
+++ b/ComputerAlgebra/Cryptology/Lisp/CryptoSystems/KeeLoq/include.mac
@@ -1,5 +1,5 @@
 /* Matthew Gwynne, 27.2.2012 (Swansea) */
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the

--- a/ComputerAlgebra/Cryptology/Lisp/CryptoSystems/plans/milestones.hpp
+++ b/ComputerAlgebra/Cryptology/Lisp/CryptoSystems/plans/milestones.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 26.2.2008 (Swansea)
-/* Copyright 2008 Oliver Kullmann
+/* Copyright 2008, 2010, 2011 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the

--- a/ComputerAlgebra/Satisfiability/Lisp/FiniteFunctions/plans/Basics.hpp
+++ b/ComputerAlgebra/Satisfiability/Lisp/FiniteFunctions/plans/Basics.hpp
@@ -1,5 +1,5 @@
 // Oliver Kullmann, 29.1.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the

--- a/ComputerAlgebra/Satisfiability/Lisp/Resolution/plans/Proofs.hpp
+++ b/ComputerAlgebra/Satisfiability/Lisp/Resolution/plans/Proofs.hpp
@@ -1,5 +1,5 @@
 // Oliver Kullmann, 7.10.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the

--- a/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/KeyDiscovery/milestones.hpp
+++ b/Experimentation/Investigations/Cryptography/AdvancedEncryptionStandard/plans/KeyDiscovery/milestones.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 26.11.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the


### PR DESCRIPTION
Branch: dates.

Updating and correcting copyright dates for recently updated files.

Now removing erroneous "2012" from ComputerAlgebra/Cryptology/Lisp/CryptoSystems/plans/milestones.hpp.

Matthew
