### PR TITLE
rucpbase_issue

### DIFF
--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_1.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_1.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -78,6 +78,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 124
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_1_fullCNF.cnf > DES_Sbox_1_pi.cnf

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_2.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_2.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -78,6 +78,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 129
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_2_fullCNF.cnf > DES_Sbox_2_pi.cnf

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_3.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_3.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -78,6 +78,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 138
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_3_fullCNF.cnf > DES_Sbox_3_pi.cnf

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_4.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_4.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -78,6 +78,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 128
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_4_fullCNF.cnf > DES_Sbox_4_pi.cnf

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_5.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_5.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -78,6 +78,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 134
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_5_fullCNF.cnf > DES_Sbox_5_pi.cnf

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_6.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_6.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -77,6 +77,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 136
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_6_fullCNF.cnf > DES_Sbox_6_pi.cnf

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_7.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_7.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -77,6 +77,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 123
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_7_fullCNF.cnf > DES_Sbox_7_pi.cnf

--- a/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_8.hpp
+++ b/Experimentation/Investigations/Cryptography/DataEncryptionStandard/plans/Sboxes/Sbox_8.hpp
@@ -1,5 +1,5 @@
 // Matthew Gwynne, 16.5.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -78,6 +78,9 @@ maxima> hardness_wpi_cs(setify(Sbox_min_F[2]), setify(Sbox_primes_F[2]));
 
   \todo 1-base : mincl_r1 <= 152
   <ul>
+   <li> The 1-bases below need to be checked to ensure they are actually
+   1-bases; see "Computing r_1-bases for a set of prime implicates" in
+   Satisfiability/Reductions/Bases/plans/UcpBase.hpp. </li>
    <li> Computing an 1-base
    \verbatim
 shell> QuineMcCluskey-n16-O3-DNDEBUG DES_Sbox_8_fullCNF.cnf > DES_Sbox_8_pi.cnf

--- a/Satisfiability/Reductions/Bases/plans/milestones.hpp
+++ b/Satisfiability/Reductions/Bases/plans/milestones.hpp
@@ -1,5 +1,5 @@
 // Oliver Kullmann, 17.1.2011 (Swansea)
-/* Copyright 2011 Oliver Kullmann
+/* Copyright 2011, 2012 Oliver Kullmann
 This file is part of the OKlibrary. OKlibrary is free software; you can redistribute
 it and/or modify it under the terms of the GNU General Public License as published by
 the Free Software Foundation and included in this library; either version 3 of the
@@ -23,6 +23,7 @@ License, or any later version. */
    In Satisfiability/Reductions/Bases/plans/UcpBase.hpp the following topics
    are handled:
     - Testcase Intransitive2 fails : DONE
+    - Computing r_1-bases for a set of prime implicates
     - Shuffling and sorting
     - Random r_1-bases
     - Random shuffling


### PR DESCRIPTION
Branch: rucpbase_issue.

The combination of RUcpGen and RUcpBase does not (necessarily) produce 1-bases of sets of prime implicates.

Providing an example of a case where this issue is exhibited, and adding todos on checking that all 1-bases we have computed are actually 1-bases. I've started these checks and so far all have been, but some of the larger clause-sets will take a little while to check in the Maxima system.

Matthew
